### PR TITLE
handle _config changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Jekyll-Heroicons
 
+## 0.3.0
+- We can define in _config.yml default variant and default classes for each variant.
 ## 0.2.1
 - Remove new line character from icon raw code.
 ## 0.2.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-heroicons (0.2.1)
+    jekyll-heroicons (0.2.4)
       jekyll
       nokogiri
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jekyll-heroicons (0.2.4)
+    jekyll-heroicons (0.3.0)
       jekyll
       nokogiri
 

--- a/lib/jekyll-heroicons.rb
+++ b/lib/jekyll-heroicons.rb
@@ -17,7 +17,7 @@ module Jekyll
     SYNTAX = /\A(#{Liquid::VariableSignature}+)/
 
     # For interpolation, look for liquid variables
-    VARIABLE = /\{\{\s*([\w]+\.?[\w]*)\s*\}\}/i
+    VARIABLE = /\{\{\s*(\w+\.?\w*)\s*\}\}/i
 
     # Copied from Liquid::TagAttributes to allow dashes in tag names:
     #
@@ -43,13 +43,34 @@ module Jekyll
 
     private
 
+    def config
+      context.registers[:site].config["heroicons"]
+    end
+
     def prepare(markup)
       @symbol = symbol(markup)
       @options = string_to_hash(markup)
-      @variant = if (match = markup.split("/")).length > 1
+      @variant = variant(markup)
+      prepend_default_classes
+    end
+
+    def variant(markup)
+      if (match = markup.split("/")).length > 1
         match.first
       elsif @options.key?(:variant)
         @options[:variant]
+      else
+        config["variant"]
+      end
+    end
+
+    def prepend_default_classes
+      return unless config.dig("default_class", @variant)
+
+      if @options[:class]
+        @options[:class] += " #{config.dig("default_class", @variant)}"
+      else
+        @options[:class] = config.dig("default_class", @variant)
       end
     end
 

--- a/lib/jekyll-heroicons.rb
+++ b/lib/jekyll-heroicons.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require_relative "jekyll-heroicons/version"
-require_relative "jekyll-heroicons/icon"
-require "liquid"
-require "jekyll/liquid_extensions"
+require_relative 'jekyll-heroicons/version'
+require_relative 'jekyll-heroicons/icon'
+require 'liquid'
+require 'jekyll/liquid_extensions'
 
 module Jekyll
   class Heroicons < Liquid::Tag
@@ -44,7 +44,9 @@ module Jekyll
     private
 
     def config
-      context.registers[:site].config["heroicons"]
+      return {} unless defined?(context) && context.registers[:site]
+
+      context.registers[:site].config['heroicons']
     end
 
     def prepare(markup)
@@ -55,22 +57,22 @@ module Jekyll
     end
 
     def variant(markup)
-      if (match = markup.split("/")).length > 1
+      if (match = markup.split('/')).length > 1
         match.first
       elsif @options.key?(:variant)
         @options[:variant]
       else
-        config["variant"]
+        config['variant']
       end
     end
 
     def prepend_default_classes
-      return unless config.dig("default_class", @variant)
+      return unless config.dig('default_class', @variant)
 
       if @options[:class]
-        @options[:class] += " #{config.dig("default_class", @variant)}"
+        @options[:class] += " #{config.dig('default_class', @variant)}"
       else
-        @options[:class] = config.dig("default_class", @variant)
+        @options[:class] = config.dig('default_class', @variant)
       end
     end
 
@@ -87,7 +89,7 @@ module Jekyll
 
       if markup.match(SYNTAX)
         markup.scan(TAG_ATTRIBUTES) do |key, value|
-          options[key.to_sym] = value.gsub(/\A"|"\z/, "")
+          options[key.to_sym] = value.gsub(/\A"|"\z/, '')
         end
       end
 
@@ -95,7 +97,7 @@ module Jekyll
     end
 
     def symbol(markup)
-      if (match = markup.split("/")).length > 1
+      if (match = markup.split('/')).length > 1
         match[1].match(SYNTAX)
       else
         markup.match(SYNTAX)
@@ -104,4 +106,4 @@ module Jekyll
   end
 end
 
-Liquid::Template.register_tag("heroicon", Jekyll::Heroicons)
+Liquid::Template.register_tag('heroicon', Jekyll::Heroicons)

--- a/lib/jekyll-heroicons.rb
+++ b/lib/jekyll-heroicons.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require_relative 'jekyll-heroicons/version'
-require_relative 'jekyll-heroicons/icon'
-require 'liquid'
-require 'jekyll/liquid_extensions'
+require_relative "jekyll-heroicons/version"
+require_relative "jekyll-heroicons/icon"
+require "liquid"
+require "jekyll/liquid_extensions"
 
 module Jekyll
   class Heroicons < Liquid::Tag
@@ -46,7 +46,7 @@ module Jekyll
     def config
       return {} unless defined?(context) && context.registers[:site]
 
-      context.registers[:site].config['heroicons']
+      context.registers[:site].config["heroicons"]
     end
 
     def prepare(markup)
@@ -57,22 +57,22 @@ module Jekyll
     end
 
     def variant(markup)
-      if (match = markup.split('/')).length > 1
+      if (match = markup.split("/")).length > 1
         match.first
       elsif @options.key?(:variant)
         @options[:variant]
       else
-        config['variant']
+        config["variant"]
       end
     end
 
     def prepend_default_classes
-      return unless config.dig('default_class', @variant)
+      return unless config.dig("default_class", @variant)
 
       if @options[:class]
-        @options[:class] += " #{config.dig('default_class', @variant)}"
+        @options[:class] += " #{config.dig("default_class", @variant)}"
       else
-        @options[:class] = config.dig('default_class', @variant)
+        @options[:class] = config.dig("default_class", @variant)
       end
     end
 
@@ -89,7 +89,7 @@ module Jekyll
 
       if markup.match(SYNTAX)
         markup.scan(TAG_ATTRIBUTES) do |key, value|
-          options[key.to_sym] = value.gsub(/\A"|"\z/, '')
+          options[key.to_sym] = value.gsub(/\A"|"\z/, "")
         end
       end
 
@@ -97,7 +97,7 @@ module Jekyll
     end
 
     def symbol(markup)
-      if (match = markup.split('/')).length > 1
+      if (match = markup.split("/")).length > 1
         match[1].match(SYNTAX)
       else
         markup.match(SYNTAX)
@@ -106,4 +106,4 @@ module Jekyll
   end
 end
 
-Liquid::Template.register_tag('heroicon', Jekyll::Heroicons)
+Liquid::Template.register_tag("heroicon", Jekyll::Heroicons)

--- a/lib/jekyll-heroicons/icon.rb
+++ b/lib/jekyll-heroicons/icon.rb
@@ -13,24 +13,14 @@ module Jekyll
         doc = Nokogiri::HTML::DocumentFragment.parse(file)
         svg = doc.at_css "svg"
 
-        prepend_default_classes
-
         @options.each do |key, value|
           svg[key.to_s] = value
         end
 
-        doc.to_html.strip
+        doc.to_html(save_with: 0).delete("\n")
       end
 
       private
-
-      def prepend_default_classes
-        if @options[:class]
-          @options[:class] += " size-6"
-        else
-          @options[:class] = "size-6"
-        end
-      end
 
       def file
         @file ||= File.read(file_path).force_encoding("UTF-8")

--- a/lib/jekyll-heroicons/version.rb
+++ b/lib/jekyll-heroicons/version.rb
@@ -5,6 +5,6 @@ module Liquid; class Tag; end; end
 
 module Jekyll
   class Heroicons < Liquid::Tag
-    VERSION = '0.3.0'
+    VERSION = "0.3.0"
   end
 end

--- a/lib/jekyll-heroicons/version.rb
+++ b/lib/jekyll-heroicons/version.rb
@@ -5,6 +5,6 @@ module Liquid; class Tag; end; end
 
 module Jekyll
   class Heroicons < Liquid::Tag
-    VERSION = "0.2.1"
+    VERSION = "0.2.4"
   end
 end

--- a/lib/jekyll-heroicons/version.rb
+++ b/lib/jekyll-heroicons/version.rb
@@ -5,6 +5,6 @@ module Liquid; class Tag; end; end
 
 module Jekyll
   class Heroicons < Liquid::Tag
-    VERSION = "0.2.4"
+    VERSION = '0.3.0'
   end
 end

--- a/test/test_heroicons.rb
+++ b/test/test_heroicons.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'test_helper'
+require_relative "test_helper"
 
 class JekyllHeroiconsTest < Minitest::Test
   def test_that_it_has_a_version_number
@@ -8,18 +8,18 @@ class JekyllHeroiconsTest < Minitest::Test
   end
 
   def test_render
-    output = render('{% heroicon solid/arrow-up %}')
-    expected_content = File.read(File.expand_path('../icons/solid/arrow-up.svg', __dir__))
+    output = render("{% heroicon solid/arrow-up %}")
+    expected_content = File.read(File.expand_path("../icons/solid/arrow-up.svg", __dir__))
 
     assert_equal append_default_classes(expected_content), output
 
-    output = render('{% heroicon outline/arrow-down %}')
-    expected_content = File.read(File.expand_path('../icons/outline/arrow-down.svg', __dir__))
+    output = render("{% heroicon outline/arrow-down %}")
+    expected_content = File.read(File.expand_path("../icons/outline/arrow-down.svg", __dir__))
 
     assert_equal append_default_classes(expected_content), output
 
     output = render('{% heroicon arrow-down variant:"micro" %}')
-    expected_content = File.read(File.expand_path('../icons/micro/arrow-down.svg', __dir__))
+    expected_content = File.read(File.expand_path("../icons/micro/arrow-down.svg", __dir__))
 
     assert_equal append_default_classes(expected_content), output
   end
@@ -30,7 +30,7 @@ class JekyllHeroiconsTest < Minitest::Test
   end
 
   def test_render_nothing
-    assert_equal '', render('{% heroicon %}')
+    assert_equal "", render("{% heroicon %}")
   end
 
   def test_parses_tag_options

--- a/test/test_heroicons.rb
+++ b/test/test_heroicons.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "test_helper"
+require_relative 'test_helper'
 
 class JekyllHeroiconsTest < Minitest::Test
   def test_that_it_has_a_version_number
@@ -8,35 +8,33 @@ class JekyllHeroiconsTest < Minitest::Test
   end
 
   def test_render
-    output = render("{% heroicon solid/arrow-up %}")
-    expected_content = File.read(File.expand_path("../icons/solid/arrow-up.svg", __dir__))
+    output = render('{% heroicon solid/arrow-up %}')
+    expected_content = File.read(File.expand_path('../icons/solid/arrow-up.svg', __dir__))
 
     assert_equal append_default_classes(expected_content), output
 
-    output = render("{% heroicon outline/arrow-down %}")
-    expected_content = File.read(File.expand_path("../icons/outline/arrow-down.svg", __dir__))
+    output = render('{% heroicon outline/arrow-down %}')
+    expected_content = File.read(File.expand_path('../icons/outline/arrow-down.svg', __dir__))
 
     assert_equal append_default_classes(expected_content), output
 
-    output = render("{% heroicon arrow-down variant:\"micro\" %}")
-    expected_content = File.read(File.expand_path("../icons/micro/arrow-down.svg", __dir__))
+    output = render('{% heroicon arrow-down variant:"micro" %}')
+    expected_content = File.read(File.expand_path('../icons/micro/arrow-down.svg', __dir__))
 
     assert_equal append_default_classes(expected_content), output
   end
 
   def append_default_classes(svg_content)
     doc = Nokogiri::HTML::DocumentFragment.parse(svg_content)
-    svg = doc.at_css "svg"
-    svg[:class] = "size-6"
-    doc.to_html.strip
+    doc.to_html.delete("\n")
   end
 
   def test_render_nothing
-    assert_equal "", render("{% heroicon %}")
+    assert_equal '', render('{% heroicon %}')
   end
 
   def test_parses_tag_options
-    output = render("{% heroicon solid/arrow-up height:32 class:\"left right\" aria-label:hi%}")
+    output = render('{% heroicon solid/arrow-up height:32 class:"left right" aria-label:hi%}')
 
     assert_match(/height="32"/, output)
     assert_match(/class="left right/, output)
@@ -44,7 +42,7 @@ class JekyllHeroiconsTest < Minitest::Test
   end
 
   def test_parses_interpolation_of_variables
-    template = render("{% assign symbol = \"solid/arrow-up\" %}{% heroicon {{ symbol }} %}")
+    template = render('{% assign symbol = "solid/arrow-up" %}{% heroicon {{ symbol }} %}')
     assert_match(/<svg.*.*/, template)
   end
 end


### PR DESCRIPTION
Adding support for default settings in `_config.yml`.

As example:
```yml
heroicons:
  variant: 'solid'
  default_class: {
    solid: "size-6",
    outline: "size-6",
    mini: "size-5",
    micro: "size-4",
  }
```