### PR TITLE
setting default variant as solid and add disable_default_class attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 - Add default variant as solid.
-
+- Adding "disable_default_class" attribute to a tag, to avoid adding default classes to the icon.
 ## 0.3.1
 - Fix Site.configuration retrieval.
 ## 0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Jekyll-Heroicons
 
+## 0.4.0
+- Add default variant as solid.
+
 ## 0.3.1
 - Fix Site.configuration retrieval.
 ## 0.3.0

--- a/README.md
+++ b/README.md
@@ -25,7 +25,34 @@ This is heavily inspired by https://github.com/jclusso/heroicons
   ```
 
 ## Usage
-Configure default settings in `_config.yml`:
+```liquid
+{% heroicon bell %}
+```
+Heroicons comes in 4 variants: `solid`, `outline`, `mini`, and `micro`. The default variant is `solid`.
+This can be changed through configuration in `_config.yml`:
+
+```ruby
+heroicons:
+  variant: 'solid'
+```
+
+Another way to provide variant and override defaults defined in config is to pass 'variant' to liquid tag:
+```liquid
+{% heroicon bell variant: "mini" %}
+```
+
+It's also possible to provide classes to the icon:
+```liquid
+{% heroicon bell class: "text-red-500" %}
+```
+
+Any other attributes will be passed to the SVG tag as well. As example:
+
+```liquid
+{% heroicon bell class: "text-red-500" aria-hidden: true height:32 aria-label:hi %}
+```
+## Configuration
+Besides variants, it's also possible to define default classes for each variant. Here is a recommended default configuration for `_config.yml`:
 
 ```ruby
 heroicons:
@@ -38,17 +65,10 @@ heroicons:
   }
 ```
 
-And then you can use:
+This default class will be applied to every icon. You can disable this on a per-icon basis by passing `disable_default_class: true`.
 
 ```liquid
-{% heroicon bell class:"right left" %}
-```
-
-Another way to provide variant would be like so:
-```liquid
-{% heroicon solid/bell class:"right left"%}
-# or
-{% heroicon bell variant: "solid" class:"right left"%}
+{% heroicon bell disable_default_class: true %}
 ```
 
 ## Development

--- a/lib/jekyll-heroicons.rb
+++ b/lib/jekyll-heroicons.rb
@@ -64,7 +64,7 @@ module Jekyll
       elsif config["variant"]
         config["variant"]
       else
-        'solid'
+        "solid"
       end
     end
 

--- a/lib/jekyll-heroicons.rb
+++ b/lib/jekyll-heroicons.rb
@@ -59,12 +59,12 @@ module Jekyll
     end
 
     def variant(markup)
-      if (match = markup.split("/")).length > 1
-        match.first
-      elsif @options.key?(:variant)
+      if @options.key?(:variant)
         @options[:variant]
-      else
+      elsif config["variant"]
         config["variant"]
+      else
+        'solid'
       end
     end
 

--- a/lib/jekyll-heroicons.rb
+++ b/lib/jekyll-heroicons.rb
@@ -38,7 +38,7 @@ module Jekyll
 
       return nil if @symbol.nil?
 
-      Icon.new(@symbol, @variant, @options.except(:variant)).raw
+      Icon.new(@symbol, @variant, @options.except(:variant, :disable_default_class)).raw
     end
 
     private
@@ -69,6 +69,7 @@ module Jekyll
     end
 
     def prepend_default_classes
+      return if @options[:disable_default_class].eql?('true')
       return unless config.dig("default_class", @variant)
 
       if @options[:class]

--- a/lib/jekyll-heroicons/version.rb
+++ b/lib/jekyll-heroicons/version.rb
@@ -5,6 +5,6 @@ module Liquid; class Tag; end; end
 
 module Jekyll
   class Heroicons < Liquid::Tag
-    VERSION = "0.3.1"
+    VERSION = "0.4.0"
   end
 end

--- a/test/test_heroicons.rb
+++ b/test/test_heroicons.rb
@@ -8,12 +8,12 @@ class JekyllHeroiconsTest < Minitest::Test
   end
 
   def test_render
-    output = render("{% heroicon solid/arrow-up %}")
-    expected_content = File.read(File.expand_path("../icons/solid/arrow-up.svg", __dir__))
+    output = render("{% heroicon arrow-up variant:outline  %}")
+    expected_content = File.read(File.expand_path("../icons/outline/arrow-up.svg", __dir__))
 
     assert_equal append_default_classes(expected_content), output
 
-    output = render("{% heroicon outline/arrow-down %}")
+    output = render("{% heroicon arrow-down variant: outline %}")
     expected_content = File.read(File.expand_path("../icons/outline/arrow-down.svg", __dir__))
 
     assert_equal append_default_classes(expected_content), output
@@ -34,7 +34,7 @@ class JekyllHeroiconsTest < Minitest::Test
   end
 
   def test_parses_tag_options
-    output = render('{% heroicon solid/arrow-up height:32 class:"left right" aria-label:hi%}')
+    output = render('{% heroicon arrow-up variant:"solid" height:32 class:"left right" aria-label:hi%}')
 
     assert_match(/height="32"/, output)
     assert_match(/class="left right/, output)


### PR DESCRIPTION
- Set default variant to 'solid'
- Support 'disable_default_class' attribute for liquid tag, so it will not apply default classes to icon.