### PR TITLE
Simplify variant method to use fallback with error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Jekyll-Heroicons
 
+## Unreleased
+- Simplified "variant" method.
+
 ## 0.4.1
 - Don't reload configuration on every change
 - Improve comments and code around picking default variants.

--- a/lib/jekyll-heroicons.rb
+++ b/lib/jekyll-heroicons.rb
@@ -63,13 +63,9 @@ module Jekyll
 
     # This method checks if heroicons liquid tag has a variant specified. If not, it check default variant in the config file. If both of those are not defined, it falls back to the default variant.
     def variant(markup)
-      if @options.key?(:variant)
-        @options[:variant]
-      elsif config["variant"]
-        config["variant"]
-      else
-        DEFAULT_VARIANT
-      end
+      @options[:variant] || config["variant"] || DEFAULT_VARIANT
+    rescue
+      DEFAULT_VARIANT
     end
 
     def prepend_default_classes

--- a/lib/jekyll-heroicons.rb
+++ b/lib/jekyll-heroicons.rb
@@ -64,8 +64,6 @@ module Jekyll
     # This method checks if heroicons liquid tag has a variant specified. If not, it check default variant in the config file. If both of those are not defined, it falls back to the default variant.
     def variant(markup)
       @options[:variant] || config["variant"] || DEFAULT_VARIANT
-    rescue
-      DEFAULT_VARIANT
     end
 
     def prepend_default_classes

--- a/lib/jekyll-heroicons.rb
+++ b/lib/jekyll-heroicons.rb
@@ -63,7 +63,7 @@ module Jekyll
 
     # This method checks if heroicons liquid tag has a variant specified. If not, it check default variant in the config file. If both of those are not defined, it falls back to the default variant.
     def variant(markup)
-      @options[:variant] || config["variant"] || DEFAULT_VARIANT
+      @options&.dig(:variant) || config&.dig("variant") || DEFAULT_VARIANT
     end
 
     def prepend_default_classes


### PR DESCRIPTION
This PR addresses #12 by adding error handling for cases where the variant setting is missing in the Jekyll config.

🔍 Issue
When variant is not specified in _config.yml, the Jekyll build process fails due to an undefined method error.

✅ Changes
* Added a fallback mechanism to handle missing variant values.

📌 Notes
* This change ensures that Jekyll can still build successfully even if variant is not explicitly defined.
* The default behavior follows the existing logic while preventing unexpected crashes.

Let me know if any modifications are needed! 🚀